### PR TITLE
v1.0.5small

### DIFF
--- a/character/sanBan.js
+++ b/character/sanBan.js
@@ -842,6 +842,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
                     nocount:true,
                 },
                 group:['san_yongHengYueZhang_jiAngKuangXiangQu','san_yongHengYueZhang_shengLiJiaoXiangShi'],
+                onremove:'storage',
                 markimage:'image/card/zhuanShu/yongHengYueZhang.png',
                 subSkill:{
                     jiAngKuangXiangQu:{

--- a/character/shenZiChuangLin.js
+++ b/character/shenZiChuangLin.js
@@ -480,7 +480,6 @@ game.import('character',function(lib,game,ui,get,ai,_status){
                 },
                 markimage:'image/card/zhuanShu/fengXue.png',
                 onremove:'storage',
-                global:'fengXueX_yingZhiFeng1_1',
                 group:['fengXueX_yingZhiFeng1_1','fengXueX_yingZhiFeng1_2','fengXueX_yingZhiFeng2','fengXueX_fengZhi'],
                 subSkill:{
                     yingZhiFeng1_1:{

--- a/character/shenZiChuangLin.js
+++ b/character/shenZiChuangLin.js
@@ -1526,7 +1526,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
                 ai:{
                     baoShi:true,
                 },
-                trigger:{player:'moFaRuMenBegin'},
+                trigger:{player:'FAQ_moFaRuMenBegin'},
                 usable:1,
                 filter:function(event,player){
                     return player.canBiShaBaoShi();

--- a/character/shiZhouNian.js
+++ b/character/shiZhouNian.js
@@ -2216,7 +2216,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
                     return player.isHengZhi()&&player.canBiShaShuiJing()&&player.getExpansions('anYue').length>0;
                 },
                 async cost(event, trigger, player) {
-                    var result=await player.chooseCardButton(player.getExpansions('anYue'),true,'是否发动【暗月斩】<br>'+lib.translate.anYueZhan_info).forResult();
+                    var result=await player.chooseCardButton(player.getExpansions('anYue'),'是否发动【暗月斩】<br>'+lib.translate.anYueZhan_info,[1, 2]).forResult();
                     event.result = {
                         bool: result.bool,
                         cost_data: result.links,

--- a/character/shiZhouNian.js
+++ b/character/shiZhouNian.js
@@ -4551,7 +4551,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
             //阴阳师
             shiShenJiangLin:{
                 type:'faShu',
-                enable:['chooseToUse','faShu'],
+                enable:['faShu'],
                 filter:function(event,player){
                     if(player.isHengZhi()) return false;
                     return player.countTongMingPai()>=2;
@@ -5843,7 +5843,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
             //灵符师
             lingFu_leiMing:{
                 type:'faShu',
-                enable:['chooseToUse','faShu'],
+                enable:['faShu'],
                 filter:function(event,player){
                     return player.countCards('h',card=>lib.skill.lingFu_leiMing.filterCard(card))>0;
                 },
@@ -7125,7 +7125,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
             },
             shengGuangBaoLie:{
                 type:'faShu',
-                enable:['chooseToUse','faShu'],
+                enable:['faShu'],
                 filter:function(event,player){
                     return player.isHengZhi();
                 },

--- a/character/shiZhouNian.js
+++ b/character/shiZhouNian.js
@@ -797,6 +797,10 @@ game.import('character',function(lib,game,ui,get,ai,_status){
                         intro:{
                             content:'expansion',
                         },
+                        onremove:function(player, skill) {
+                            const cards = player.getExpansions(skill);
+                            if (cards.length) player.loseToDiscardpile(cards);
+                        },
                         trigger:{player:['daChuPai','showCardsEnd']},
                         forced:true,
                         priority:1,
@@ -6265,6 +6269,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
                     content:"[响应]激昂狂想曲：<span class='tiaoJian'>(回合开始时若你拥有【永恒乐章】)</span>选择以下一项执行：<br>·吟游诗人对2名目标对手各造成1点法术伤害③。 <br>·你弃2张牌。<br>[响应]胜利交响诗：<span class='tiaoJian'>(回合结束时若你拥有【永恒乐章】)</span>选择以下一项执行<br>·将我方【战绩区】的1个星石提炼成为你的能量。<br>·为我方【战绩区】+1[宝石]，你+1[治疗]。",
                     nocount:true,
                 },
+                onremove:'storage',
                 group:['yongHengYueZhang_jiAngKuangXiangQu','yongHengYueZhang_shengLiJiaoXiangShi'],
                 markimage:'image/card/zhuanShu/yongHengYueZhang.png',
                 subSkill:{

--- a/character/shiZhouNian.js
+++ b/character/shiZhouNian.js
@@ -1297,7 +1297,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
                         list.push(['baoShi','宝石']);
                     }
                     for(var i=0;i<player.countNengLiang('shuiJing');i++){
-                        list.push('shuiJing','水晶');
+                        list.push(['shuiJing','水晶']);
                     }
                     var result = await player.chooseButton(['是否发动【神之庇护】<br>'+lib.translate.shenZhiBiHu_info,[list,'tdnodes']])
                     .set('selectButton',[1,-trigger.num])

--- a/character/shiZhouNian.js
+++ b/character/shiZhouNian.js
@@ -6638,7 +6638,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
                                 await player.addZhiShiWu('nuQi',nuQi);
                             }
                             if(num>0){
-                                trigger.getParent().changeDamageNum(num);
+                                trigger.changeDamageNum(num);
                                 await player.faShuDamage(num,player);
                             }
                             await event.trigger('jinDuanZhiLi');

--- a/character/shiZhouNian.js
+++ b/character/shiZhouNian.js
@@ -8693,7 +8693,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
                         var targets=await player.chooseTarget("对目标角色造成1点法术伤害③，该伤害不能用[治疗]抵御",true)
                         .set('ai',function(target){
                             var player=_status.event.player;
-                            return gat.damageEffect2(target,player,1);
+                            return get.damageEffect2(target,player,1);
                         }).forResultTargets();
                         var target=targets[0];
                         await target.faShuDamage(1,player).set('canZhiLiao',false);

--- a/character/shiZhouNian.js
+++ b/character/shiZhouNian.js
@@ -2188,7 +2188,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
             },
             yueDu:{
                 usable:1,
-                trigger:{source:'chengShouShangHai'},
+                trigger:{source:'chengShouShangHaiAfter'},
                 filter:function(event,player){
                     return event.faShu==true&&player.zhiLiao>0;
                 },

--- a/character/shiZhouNian.js
+++ b/character/shiZhouNian.js
@@ -3519,7 +3519,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
                         event.target=result.targets[0];
                         if(result.targets[0].countNengLiang('shuiJing')){
                             event.target.removeNengLiang('shuiJing');
-                        }
+                        }else event.finish();
                     }else event.finish()
                     'step 3'
                     event.target.addNengLiang('baoShi');

--- a/character/shiZhouNian.js
+++ b/character/shiZhouNian.js
@@ -7660,7 +7660,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
                 }
             },
             yiJiWuNian:{
-                trigger:{player:'gongJiEnd'},
+                trigger:{player:'gongJiAfter'},
                 filter:function(event,player){
                     return get.is.gongJiXingDong(event)&&player.countZhiShiWu('canXin')>=4;
                 },

--- a/character/shiZhouNian.js
+++ b/character/shiZhouNian.js
@@ -1423,13 +1423,9 @@ game.import('character',function(lib,game,ui,get,ai,_status){
                     result:{
                         target:function(player,target){
                             var num=target.countCards('h');
-                            if(num<5) return -5;
+                            if(num<5&&player.canGongJi()) return -5;
                             else return 0;
                         },
-                        player:function(player,target){
-                            if(player.canGongJi()) return 1;
-                            else return -10;
-                        }
                     }
                 }
             },

--- a/character/shiZhouNian.js
+++ b/character/shiZhouNian.js
@@ -4171,9 +4171,9 @@ game.import('character',function(lib,game,ui,get,ai,_status){
                 trigger:{source:'gongJiWeiMingZhong'},
                 filter:function(event,player){
                     if(event.yingZhan==true) return false;
+                    if(event.nuHuoYaZhi==false) return false;
                     return player.countZhiShiWu('zhanWen')>=1;
                 },
-                priority:1,
                 content:function(){
                     lib.skill.zhanWenZhangWo.fanZhuanZhanWen(player,1);
                     trigger.moWenRongHe=false
@@ -4205,7 +4205,6 @@ game.import('character',function(lib,game,ui,get,ai,_status){
                         .forResult();
                 },
                 content:async function(event, trigger, player){
-                    'step 0'
                     var num=event.cards.length-1;
                     await player.discard(event.cards).set('showCards',true);
                     await lib.skill.zhanWenZhangWo.fanZhuanZhanWen(player,1);
@@ -4222,7 +4221,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
                             await lib.skill.zhanWenZhangWo.fanZhuanZhanWen(player,control);
                         }
                     }
-                    trigger.changeDamageNum(num);
+                    await trigger.changeDamageNum(num);
                 }
             },
             moWenRongHe:{
@@ -4244,6 +4243,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
                         .forResult();
                 },
                 content:async function(event, trigger, player){
+                    trigger.nuHuoYaZhi=false;
                     await lib.skill.zhanWenZhangWo.fanZhuanMoWen(player,1);
                     await player.discard(event.cards).set('showCards',true);
                     var num=event.cards.length-1;
@@ -4260,8 +4260,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
                             await lib.skill.zhanWenZhangWo.fanZhuanMoWen(player,control);
                         }
                     }
-                    'step 4'
-                    trigger.player.faShuDamage(num,player);
+                    await trigger.player.faShuDamage(num,player);
                 }
             },
             fuWenGaiZao:{

--- a/character/shiZhouNian.js
+++ b/character/shiZhouNian.js
@@ -7697,7 +7697,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
                     return event.zhiShiWu=='shouHun'&&event.num<0;
                 },
                 content:function(){
-                    player.addZhiShiWu('canXin',trigger.num);
+                    player.addZhiShiWu('canXin',-trigger.num);
                 },
                 group:'shouHunYiNian_zhuDongGongJiMingZhong',
                 subSkill:{

--- a/character/shiZhouNian.js
+++ b/character/shiZhouNian.js
@@ -4206,21 +4206,22 @@ game.import('character',function(lib,game,ui,get,ai,_status){
                 },
                 content:async function(event, trigger, player){
                     var num=event.cards.length-1;
-                    await player.discard(event.cards).set('showCards',true);
-                    await lib.skill.zhanWenZhangWo.fanZhuanZhanWen(player,1);
-                    if(player.isHengZhi()&&player.countZhiShiWu('zhanWen')>0){
+                    var zhanWenNum=1;
+                    if(player.isHengZhi()&&player.countZhiShiWu('zhanWen')>1){
                         var list=[];
-                        for(var i=0;i<=player.countZhiShiWu('zhanWen');i++){
+                        for(var i=0;i<=player.countZhiShiWu('zhanWen')-1;i++){
                             list.push(i);
                         }
-                        var control=await player.chooseControl(list).set('prompt','额外翻转【战纹】数量').set('ai',function(){
+                        var control=await player.chooseControl(list).set('prompt',`额外翻转Y个【战纹】，本次攻击伤害额外+(${num}+Y)`).set('ai',function(){
                             return list.length;
                         }).set('num',list.length).forResultControl();
                         if(control>0){
                             num+=control;
-                            await lib.skill.zhanWenZhangWo.fanZhuanZhanWen(player,control);
+                            zhanWenNum+=control;
                         }
                     }
+                    await lib.skill.zhanWenZhangWo.fanZhuanZhanWen(player,zhanWenNum);
+                    await player.discard(event.cards).set('showCards',true);
                     await trigger.changeDamageNum(num);
                 }
             },
@@ -4244,22 +4245,23 @@ game.import('character',function(lib,game,ui,get,ai,_status){
                 },
                 content:async function(event, trigger, player){
                     trigger.nuHuoYaZhi=false;
-                    await lib.skill.zhanWenZhangWo.fanZhuanMoWen(player,1);
-                    await player.discard(event.cards).set('showCards',true);
                     var num=event.cards.length-1;
-                    if(player.isHengZhi()&&player.countZhiShiWu('moWen')>0){
+                    var moWenNum=1;
+                    if(player.isHengZhi()&&player.countZhiShiWu('moWen')>1){
                         var list=[];
-                        for(var i=0;i<=player.countZhiShiWu('moWen');i++){
+                        for(var i=0;i<=player.countZhiShiWu('moWen')-1;i++){
                             list.push(i);
                         }
-                        var control=await player.chooseControl(list).set('prompt','额外翻转【魔纹】数量').set('ai',function(){
+                        var control=await player.chooseControl(list).set('prompt',`额外翻转Y个【魔纹】，本次法术伤害为${num}+Y`).set('ai',function(){
                             return list.length;
                         }).set('num',list.length).forResultControl();
                         if(control>0){
                             num+=control;
-                            await lib.skill.zhanWenZhangWo.fanZhuanMoWen(player,control);
+                            moWenNum+=control;
                         }
                     }
+                    await lib.skill.zhanWenZhangWo.fanZhuanMoWen(player,moWenNum);
+                    await player.discard(event.cards).set('showCards',true);
                     await trigger.player.faShuDamage(num,player);
                 }
             },

--- a/character/shiZhouNian.js
+++ b/character/shiZhouNian.js
@@ -2288,7 +2288,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
                         },
                         content:function(){
                             'step 0'
-                            player.canYingZhan=true;
+                            trigger.wuFaYingZhan();
                             'step 1'
                             player.removeSkill('cangBaiZhiYue_wuFaYingZhan');
                         }

--- a/character/yiDuanYeHuo.js
+++ b/character/yiDuanYeHuo.js
@@ -470,13 +470,15 @@ game.import('character',function(lib,game,ui,get,ai,_status){
 
                     if(player.countCards('h')>0){
                         var cards=await player.chooseToDiscard('h',1,true).forResultCards();
-                        result=await player.chooseCardButton(cards,'是否展示,对目标角色造成1点法术伤害③')
+                        result=await player.chooseCardButton(cards,'是否展示,对目标对手造成1点法术伤害③')
                         .set('filterButton',function(button){
                             return get.mingGe(button.link)=='sheng';
                         }).forResult();
                         if(result.bool){
                             await player.showCards(result.links);
                             var targets=await player.chooseTarget('对目标对手造成1点法术伤害③',true,function(card,player,target){
+                                return target.side!=player.side;
+                            }).set('ai',function(target){
                                 var player=_status.event.player;
                                 return get.damageEffect2(target,player,1);
                             }).forResultTargets();

--- a/noname/game/index.js
+++ b/noname/game/index.js
@@ -55,6 +55,7 @@ export class Game extends GameCompatible {
 		});
 		game.changeShiQi(game.shiQiMax,true,false);
 		game.changeShiQi(game.shiQiMax,false,false);
+		return ui.shiQiInfo;
 	}
 
 	documentZoom;
@@ -8832,6 +8833,7 @@ export class Game extends GameCompatible {
 			ui.updateShiQiInfo();
 		},game.hongShiQi,game.lanShiQi);
 		game.addVideo('changeShiQi',null,[numx,side]);
+		return ui.shiQiInfo;
 	}
 	/**
 	 * 更改战绩星石
@@ -8893,6 +8895,7 @@ export class Game extends GameCompatible {
 			ui.updateShiQiInfo();
 		},game.hongZhanJi,game.lanZhanJi);
 		game.addVideo('changeZhanJi',null,[numx,xingShi,side]);
+		return ui.shiQiInfo;
 	}
 	/**
 	 * 更改星杯数量
@@ -8932,6 +8935,7 @@ export class Game extends GameCompatible {
 			ui.updateShiQiInfo();
 		},game.hongXingBei,game.lanXingBei);
 		game.addVideo('changeXingBei',null,[numx,side]);
+		return ui.shiQiInfo; 
 	}
 	/**
 	 * 魔弹重置数据
@@ -8942,6 +8946,7 @@ export class Game extends GameCompatible {
 		game.broadcastAll(function(){
 			game.moDanFangXiang='you';
 		});
+		return [game.moDan,game.moDanFangXiang];
 	}
 }
 

--- a/noname/get/is.js
+++ b/noname/get/is.js
@@ -13,7 +13,7 @@ export class Is {
 	}
 	//useSkill||useCard
 	gongJi(event){
-		return get.type(event.card)=='gongJi'&&event.oriTargets.length>0	;
+		return get.type(event.card)=='gongJi'&&event.oriTarget;
 	}
 	yingZhanGongJi(event){
 		//if(!get.is.gongJi(event)) return false;

--- a/noname/library/element/content.js
+++ b/noname/library/element/content.js
@@ -8539,7 +8539,7 @@ export const Content = {
 		if(event.targets.length>0){
 			event.target=event.targets[0];
 			event.source=player;
-			event.oriTargets=event.target;
+			event.oriTarget=event.target;
 		}
 		if(event.getParent().firstAction) event.firstAction=true;
 		var type=get.type(card);

--- a/noname/library/element/gameEvent.js
+++ b/noname/library/element/gameEvent.js
@@ -1312,6 +1312,7 @@ export class GameEvent {
 	//xingBei
 	weiMingZhong(){
 		this.target=undefined;
+		return this;
 	}
 	/**
 	 * @param {num} num 伤害改变量 
@@ -1320,7 +1321,7 @@ export class GameEvent {
 		if(typeof num != 'number' || !num) num = 1;
 		if(this.name=='zhiLiao'){
 			this.getParent().num+=num;
-			return;
+			return this;
 		}
 		if(typeof this.damageNum == 'number' || typeof this.num == 'number'){
 			if(typeof this.damageNum == 'number') this.damageNum += num;
@@ -1331,6 +1332,7 @@ export class GameEvent {
 			this.getParent().damageNum += num;
 			if(this.getParent().damageNum < 0) this.getParent().damageNum = 0;
 		}
+		return this;
 	}
 	/** 
 	 * 设置攻击效果 主要在攻击设置/攻击前时机调用
@@ -1345,7 +1347,7 @@ export class GameEvent {
 			this.getParent().canShengGuang=false;
 			this.getParent().canShengDun=false;1
 		}
-		
+		return this;
 	}
 	wuFaYingZhan(){
 		if(this.canYingZhan!=undefined){
@@ -1353,6 +1355,7 @@ export class GameEvent {
 		}else{
 			this.getParent().canYingZhan=false;
 		}
+		return this;
 	}
 	wuFaShengGuang(){
 		if(this.canShengGuang!=undefined){
@@ -1360,6 +1363,7 @@ export class GameEvent {
 		}else{
 			this.getParent().canShengGuang=false;
 		}
+		return this;
 	}
 	wuFaShengDun(){
 		if(this.canShengDun!=undefined){
@@ -1367,5 +1371,6 @@ export class GameEvent {
 		}else{
 			this.getParent().canShengDun=false;
 		}
+		return this;
 	}
 }

--- a/noname/library/element/player.js
+++ b/noname/library/element/player.js
@@ -10475,6 +10475,7 @@ export class Player extends HTMLDivElement {
 		var next=game.createEvent('wuFaXingDong',false);
 		next.player = this;
 		next.setContent(lib.skill._wuFaXingDong.contentx);
+		return next;
 	}
 	moDan(use){
 		var next=game.createEvent('moDan',false);
@@ -10892,14 +10893,14 @@ export class Player extends HTMLDivElement {
 			return next;
 		}else{
 			if(this.hasNengLiang('shuiJing')){
-				this.removeNengLiang('shuiJing');
+				return this.removeNengLiang('shuiJing');
 			}else if(this.hasNengLiang('baoShi')){
-				this.removeNengLiang('baoShi');
+				return this.removeNengLiang('baoShi');
 			}
 		}
 	}
 	removeBiShaBaoShi(){//移除宝石
-		this.removeNengLiang('baoShi');
+		return this.removeNengLiang('baoShi');
 	}
 	changeNengLiang(xingShi,num){//改变能量
 		if(xingShi==undefined) return;
@@ -10927,12 +10928,12 @@ export class Player extends HTMLDivElement {
 	}
 	addNengLiang(xingShi,num){//添加能量
 		if(typeof num!='number'||!num) num=1;
-		this.changeNengLiang(xingShi,num);
+		return this.changeNengLiang(xingShi,num);
 	}
 	removeNengLiang(xingShi,num){//移除能量
 		if(typeof num!='number'||!num) num=-1;
 		if(num>0) num=-num;
-		this.changeNengLiang(xingShi,num);
+		return this.changeNengLiang(xingShi,num);
 	}
 	countNengLiang(xingShi){//统计某个能量数
 		if(xingShi==undefined) return 0;
@@ -11042,7 +11043,7 @@ export class Player extends HTMLDivElement {
 		}
 		if(!num) num=-1;
 		if(num>0) num=-num;
-		this.changeZhiShiWu(zhiShiWu,num,true);
+		return this.changeZhiShiWu(zhiShiWu,num,true);
 	}
 	//指示物是否到达上限
 	isZhiShiWuMax(zhiShiWu){
@@ -11056,8 +11057,8 @@ export class Player extends HTMLDivElement {
 
 	setZhiShiWu(zhiShiWu, num) {
 		const count = this.countMark(zhiShiWu);
-		if (count > num) this.removeZhiShiWu(zhiShiWu, count - num);
-		else if (count < num) this.addZhiShiWu(zhiShiWu, num - count);
+		if (count > num) return this.removeZhiShiWu(zhiShiWu, count - num);
+		else if (count < num) return this.addZhiShiWu(zhiShiWu, num - count);
 	}
 	hasZhiShiWu(zhiShiWu){//是否拥有指示物
 		return this.hasMark(zhiShiWu);
@@ -11065,12 +11066,12 @@ export class Player extends HTMLDivElement {
 
 	addZhanJi(xingShi,num){//增加战绩
 		if(typeof num!='number'||!num) num=1;
-		this.changeZhanJi(xingShi,num);
+		return this.changeZhanJi(xingShi,num);
 	}
 	removeZhanJi(xingShi,num){//移除战绩
 		if(typeof num!='number'||!num) num=-1;
 		if(num>0) num=-num;
-		this.changeZhanJi(xingShi,num);
+		return this.changeZhanJi(xingShi,num);
 	}
 	chongZhi(){//重置
 		if(this.isLinked()){
@@ -11091,7 +11092,7 @@ export class Player extends HTMLDivElement {
 	qiPai(){//执行一次超出手牌上限的弃牌
 		var num=this.needsToDiscard();
 		if(num>0){
-			this.chooseToDiscard(num,true).set('useCache',true).set('baoPai',true);
+			return this.chooseToDiscard(num,true).set('useCache',true).set('baoPai',true);
 		}
 	}
 	countTongXiPai(type){//统计同系牌数
@@ -11159,8 +11160,7 @@ export class Player extends HTMLDivElement {
 			var skill=skills[i];
 			var info=get.info(skill);
 			if(info.intro&&info.markimage=='image/card/zhiShiWu/hong.png'){
-				this.changeZhiShiWu(skill,num,max);
-				break;
+				return this.changeZhiShiWu(skill,num,max);
 			}
 		}
 	}
@@ -11171,28 +11171,27 @@ export class Player extends HTMLDivElement {
 			var skill=skills[i];
 			var info=get.info(skill);
 			if(info.intro&&info.markimage=='image/card/zhiShiWu/lan.png'){
-				this.changeZhiShiWu(skill,num,max);
-				break;
+				return this.changeZhiShiWu(skill,num,max);
 			}
 		}
 	}
 	addHong(num,max){//添加红点
 		if(typeof num!='number'||!num) num=1;
-		this.changeHong(num,max);
+		return this.changeHong(num,max);
 	}
 	removeHong(num){//移除红点
 		if(typeof num!='number'||!num) num=-1;
 		if(num>0) num=-num;
-		this.changeHong(num);
+		return this.changeHong(num);
 	}
 	addLan(num,max){//添加蓝点
 		if(typeof num!='number'||!num) num=1;
-		this.changeLan(num,max);
+		return this.changeLan(num,max);
 	}
 	removeLan(num){//移除蓝点
 		if(typeof num!='number'||!num) num=-1;
 		if(num>0) num=-num;
-		this.changeLan(num);
+		return this.changeLan(num);
 	}
 	/**
 	 * 
@@ -11240,12 +11239,14 @@ export class Player extends HTMLDivElement {
 		return next;
 	}
 	addZhiLiao(num,limit){
-		this.changeZhiLiao(num,limit);
+		if(num==undefined) num=1;
+		if(num<0) num=-num;
+		return this.changeZhiLiao(num,limit);
 	}
 	removeZhiLiao(num){
 		if(typeof num!='number') num=-1;
 		if(num>0) num=-num;
-		this.changeZhiLiao(num);
+		return this.changeZhiLiao(num);
 	}
 
 	countEmptyCards(){
@@ -11273,15 +11274,15 @@ export class Player extends HTMLDivElement {
 	
 	addGongJiOrFaShu(num){
 		if(typeof num!='number') num=1;
-		this.storage.gongJiOrFaShu+=num;
+		return this.storage.gongJiOrFaShu+=num;
 	}
 	addGongJi(num){
 		if(typeof num!='number') num=1;
-		this.storage.gongJi+=num;
+		return this.storage.gongJi+=num;
 	}
 	addFaShu(num){
 		if(typeof num!='number') num=1;
-		this.storage.faShu+=num;
+		return this.storage.faShu+=num;
 	}
 
 	gainJiChuXiaoGuo(target){

--- a/noname/library/element/player.js
+++ b/noname/library/element/player.js
@@ -3531,7 +3531,7 @@ export class Player extends HTMLDivElement {
 				hp.classList.add("text");
 			} else if (get.is.newLayout() && (maxHp > 9 || (maxHp > 5 && this.classList.contains("minskin")) || ((game.layout == "mobile" || game.layout == "long") && this.dataset.position == 0 && maxHp > 7))) {
 			 */
-			} else if (maxHp > 5) {
+			} else if (maxHp > 8) {
 				hp.innerHTML = this.hp + "<br>/<br>" + maxHp + "<div></div>";
 				if (this.hp == 0) {
 					hp.lastChild.classList.add("lost");

--- a/noname/library/element/player.js
+++ b/noname/library/element/player.js
@@ -10957,20 +10957,21 @@ export class Player extends HTMLDivElement {
 	*/
 	changeZhiShiWu () {
 		var num_flag=0;
+		var num,max,zhiShiWu,forced;
 		for(var i=0;i<arguments.length;i++){
 			if(typeof arguments[i]=='number'){
 				if(num_flag==0){
-					var num=arguments[i];
-					var num_flag=1;
+					num=arguments[i];
+					num_flag=1;
 				}else if(num_flag==1){
-					var max=arguments[i];
+					max=arguments[i];
 				}
 			}
 			else if(typeof arguments[i]=='string'){
-				var zhiShiWu=arguments[i];
+				zhiShiWu=arguments[i];
 			}
 			else if(typeof arguments[i]=='boolean'){
-				var forced=arguments[i];
+				forced=arguments[i];
 			}
 		}
 		if(!this.hasSkill(zhiShiWu)&&!forced) return;
@@ -10978,11 +10979,11 @@ export class Player extends HTMLDivElement {
 		var info=get.info(zhiShiWu);
 		if(num>0){
 			if(typeof max=='number'){
-				var max=max;
+				max=max;
 			}else if(info&&info.intro&&info.intro.max){
-				var max=info.intro.max;
+				max=info.intro.max;
 			}else{
-				var max=Infinity;
+				max=Infinity;
 			}
 			var current=this.countMark(zhiShiWu);
 			if(current+num>max){
@@ -11001,10 +11002,32 @@ export class Player extends HTMLDivElement {
 			next.num=num;
 			next.setContent('changeZhiShiWu');
 			return next;
+		}else{
+			return;
 		}
 	}
-	addZhiShiWu(...args){//添加指示物
-		this.changeZhiShiWu(...args);
+	addZhiShiWu(){//添加指示物
+		var num_flag=0;
+		var num,max,zhiShiWu,forced;
+		for(var i=0;i<arguments.length;i++){
+			if(typeof arguments[i]=='number'){
+				if(num_flag==0){
+					num=arguments[i];
+					num_flag=1;
+				}else if(num_flag==1){
+					max=arguments[i];
+				}
+			}
+			else if(typeof arguments[i]=='string'){
+				zhiShiWu=arguments[i];
+			}
+			else if(typeof arguments[i]=='boolean'){
+				forced=arguments[i];
+			}
+		}
+		if(typeof num!='number'||!num) num=1;
+		if(num<0) num=-num;
+		return this.changeZhiShiWu(num,max,zhiShiWu,forced);
 	}
 	countZhiShiWu(zhiShiWu){//统计指示物
 		return this.countMark(zhiShiWu);

--- a/noname/library/index.js
+++ b/noname/library/index.js
@@ -4081,8 +4081,8 @@ export class Library {
 					},
 				},
 				show_sex: {
-					name: "显示角色性别",
-					intro: "在角色的右键菜单中显示角色性别",
+					name: "显示角色名字",
+					intro: "在角色的右键菜单中显示角色名字",
 					init: true,
 					unfrequent: true,
 				},


### PR DESCRIPTION
完善代码
修复兽魂意念未正确增加残心
修复一击无念错误时机
修复暗月斩强制发动以及无法选择2个暗月
修复苍白之月下次主动攻击可以应战
优化狙击ai
修复禁断之力未正确增伤
修复神之庇护未正确显示水晶
修复月渎错误时机
修复未正确为oriTarget赋值
修复血染蔷薇可以给赠一个宝石
修复FAQ魔法入门无法争取触发FAQ友情羁绊
修复恩典神授可以指定目标角色造成伤害
优化英灵人形攻击未命中时技能触发逻辑
优化战纹碎击和魔纹融合操作逻辑
优化高治疗上限情况下治疗显示
修复倒逆之蝶选项一ai错误使用函数