### PR TITLE
v1.2.2

### DIFF
--- a/character/shenZiChuangLin.js
+++ b/character/shenZiChuangLin.js
@@ -232,7 +232,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
                 },
             },
             ren: {
-                global: ["ren_zhuanHuan1","ren_zhuanHuan2","ren_daChuQiZhi","ren_gaiPai","ren_biaoJi",'ren_cardsDiscardEnd','ren_mod'],
+                global: ["ren_zhuanHuan1","ren_zhuanHuan2","ren_daChuQiZhi","ren_gaiPai","ren_biaoJi",'ren_cardsDiscardEnd','ren_mod','ren_cardsDiscardEnd'],
                 contentx: function(){
                     for(var card of event.cards){
                         if(card.name=='moRen'){

--- a/character/shiZhouNian.js
+++ b/character/shiZhouNian.js
@@ -5366,11 +5366,11 @@ game.import('character',function(lib,game,ui,get,ai,_status){
                 },
                 ai:{
                     baoShi:true,
-                    order:3.7,
+                    order:3.5,
                     result:{
                         target:function(player,target){
-                            if(player.countTongXiPai()<3) return 0;
-                            return get.damageEffect(target,2);
+                            if(player.countYiXiPai()<3) return 0;
+                            return get.damageEffect(target,player.countYiXiPai()-1);
                         },
                     }
                 }

--- a/character/shiZhouNian.js
+++ b/character/shiZhouNian.js
@@ -8763,8 +8763,14 @@ game.import('character',function(lib,game,ui,get,ai,_status){
                     var cards=player.getExpansions('jian');
                     var result=await player.chooseCardButton(cards,"是否发动【朝圣】,移除1个【茧】,抵御1点该来源的伤害,目前伤害量"+trigger.num)
                     .set('ai',function(button){
-                        return 0;
-                    })
+                        var player=_status.event.player;
+                        var num=_status.event.num;
+                        var shiQiXiaJiang=_status.event.shiQiXiaJiang;
+                        if(shiQiXiaJiang!=false&&player.countCards('h')+num>player.getHandcardLimit()){
+                            if(get.type(button.link)=='faShu') return 1;
+                            else return 2;
+                        }else return 0;
+                    }).set('num',trigger.num).set('shiQiXiaJiang',trigger.shiQiXiaJiang)
                     .forResult();
                     event.result={
                         bool:result.bool,

--- a/character/shiZhouNian.js
+++ b/character/shiZhouNian.js
@@ -3590,8 +3590,11 @@ game.import('character',function(lib,game,ui,get,ai,_status){
                     player.addGongJi();
                 },
                 check:function(event,player){
-                    var shiQi=get.shiQi(player.side);
-                    return shiQi>5;
+                    if(player.countZhiShiWu('xianXue')>=2) return true;
+                    if(player.countCards('h',card=>get.xiBie(card)=='an')>0) return true;
+
+                    if(player.countCards('h')+2>player.getHandcardLimit()) return false;
+                    else return true;
                 }
 
             },

--- a/character/shiZhouNian.js
+++ b/character/shiZhouNian.js
@@ -6360,14 +6360,16 @@ game.import('character',function(lib,game,ui,get,ai,_status){
                 trigger:{global:'yongHengYueZhang'},
                 forced:true,
                 filter:function(event,player){
-                    return event.player==player.storage.yongHengYueZhang_target||event.player==player;
+                    return event.player==player.storage.yongHengYueZhang_target;
                 },
                 content:async function(event,trigger,player){
                     var info=get.info('lingGan');
                     if(player.countZhiShiWu('lingGan')<info.intro.max){
                         await player.addZhiShiWu('lingGan');
-                        await player.storage.yongHengYueZhang_target.removeZhiShiWu('yongHengYueZhang');
-                        player.storage.yongHengYueZhang_target=undefined;
+                        if(player.storage.yongHengYueZhang_targe){
+                            await player.storage.yongHengYueZhang_target.removeZhiShiWu('yongHengYueZhang');
+                            delete player.storage.yongHengYueZhang_target;
+                        }
                     }else{
                         await player.faShuDamage(3,player);
                         await player.hengZhi();

--- a/character/shiZhouNian.js
+++ b/character/shiZhouNian.js
@@ -3240,13 +3240,9 @@ game.import('character',function(lib,game,ui,get,ai,_status){
                     return target!=player;
                 },
                 content:async function(event, trigger, player){
-                    var shiQiListBefore=[get.shiQi(true),get.shiQi(false)];
                     await event.target.faShuDamage(1,player).set('wenYi',true);
-                    var shiQiAfter=[get.shiQi(true),get.shiQi(false)];
-                    if(shiQiListBefore[0]!=shiQiAfter[0]||shiQiListBefore[1]!=shiQiAfter[1]){
-                        player.addTempSkill('wenYi_zhiLiao');
-                    }
                 },
+                group:'wenYi_shiQiXiaJiang',
                 subSkill:{
                     zhiLiao:{
                         trigger:{player:'phaseEnd'},
@@ -3255,7 +3251,20 @@ game.import('character',function(lib,game,ui,get,ai,_status){
                             player.changeZhiLiao(1);
                             player.removeSkill('wenYi_zhiLiao');
                         }
-                    }
+                    },
+                    shiQiXiaJiang:{
+                        trigger:{global:'changeShiQiAfter'},
+                        lastDo:true,
+                        direct:true,
+                        filter:function(event,player){
+                            return event.getParent('damage').wenYi==true&&event.num<0;
+                        },
+                        content:function(){
+                            if(!player.hasSkill('wenYi_zhiLiao')){
+                                player.addTempSkill('wenYi_zhiLiao');
+                            }
+                        }
+                    },
                 },
                 ai:{
                     order:3.6,

--- a/character/shiZhouNian.js
+++ b/character/shiZhouNian.js
@@ -5416,7 +5416,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
                     result:{
                         target:function(player,target){
                             if(player.side!=target.side) return 0;
-                            return get.zhiLiaoEffect(target,2)-0.1;
+                            return get.zhiLiaoEffect(target,2);
                         },
                     }
                 }

--- a/character/yiDuanYeHuo.js
+++ b/character/yiDuanYeHuo.js
@@ -964,7 +964,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
                         var bool1=_status.event.bool1;
                         var bool2=_status.event.bool2;
                         var player=_status.event.player;
-                        if(player.getExpansions('luEn').length>2&&bool2) return '选项二';
+                        if(player.getExpansions('luEn').length>=5&&bool2) return '选项二';
                         if(bool1) return '选项一';
                     }).set('bool1',bool1).set('bool2',bool2);
                     'step 1'

--- a/character/yiDuanYeHuo.js
+++ b/character/yiDuanYeHuo.js
@@ -830,8 +830,8 @@ game.import('character',function(lib,game,ui,get,ai,_status){
                 content:function(){
                     'step 0'
                     player.removeBiShaShuiJing();
+                    player.storage.moLiShangZeng=false;
                     'step 1'
-                    event.shiQiListBefore=[get.shiQi(true),get.shiQi(false)];
                     player.chooseTarget('对目标对手造成1点法术伤害③',true,function(card,player,target){
                         return target.side!=player.side;
                     }).set('ai',function(target){
@@ -839,12 +839,25 @@ game.import('character',function(lib,game,ui,get,ai,_status){
                         return get.damageEffect2(target,player,1);
                     });
                     'step 2'
-                    result.targets[0].faShuDamage(1,player);
+                    result.targets[0].faShuDamage(1,player).set('moLiShangZeng',true);
                     'step 3'
-                    event.shiQiListAfter=[get.shiQi(true),get.shiQi(false)];
-                    if((event.shiQiListBefore[0]==event.shiQiListAfter[0])&&(event.shiQiListBefore[1]==event.shiQiListAfter[1])){
+                    if(!player.storage.moLiShangZeng){
                         player.addZhanJi('baoShi');
                     }
+                },
+                group:'moLiShangZeng_shiQiXiaJiang',
+                subSkill:{
+                    shiQiXiaJiang:{
+                        trigger:{global:'changeShiQiAfter'},
+                        lastDo:true,
+                        direct:true,
+                        filter:function(event,player){
+                            return event.getParent('damage').moLiShangZeng==true&&event.num<0;
+                        },
+                        content:function(){
+                            player.storage.moLiShangZeng=true;
+                        }
+                    },
                 },
                 ai:{
                     shuiJing:true,

--- a/character/zhongMoDaoZhu.js
+++ b/character/zhongMoDaoZhu.js
@@ -837,7 +837,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
                     next.set('prompt2',lib.translate.daoGaoShi_info);
                     next.set('ai',function(target){
                         var player=_status.event.player;
-                        return get.zhiLiaoEffect2(target,player,1)-0.1;
+                        return get.zhiLiaoEffect2(target,player,1);
                     });
                     event.result=await next.forResult();
                 },

--- a/character/zhongMoDaoZhu.js
+++ b/character/zhongMoDaoZhu.js
@@ -747,7 +747,7 @@ game.import('character',function(lib,game,ui,get,ai,_status){
                     await player.addZhiShiWu('shengYiWu',2);
                     if(!player.hasSkill('wangQuanBaoZhuX')) player.addSkill('wangQuanBaoZhuX');
                     for(var current of game.players) current.storage.wangQuanBaoZhuX_player=player;
-                    await player.addToExpansion(event.cards,player,'gain2').set('type','fangZhi').set('gaintag',['wangQuanBaoZhuX_biaoJi']);
+                    await player.addToExpansion(event.cards,player,'gain2').set('type','fangZhi').set('gaintag',['wangQuanBaoZhuX_biaoJi']).set('special',true);
                 },
                 group:'xinYangChongZhu_teShu',
                 subSkill:{

--- a/game/asset.js
+++ b/game/asset.js
@@ -1,6 +1,6 @@
 window.noname_asset_list=
 [
-	"v1.1.2",
+	"v1.2.1",
 	"audio/background/music_default.mp3",
 	"audio/card/default.mp3",
 	'audio/card/atk_an.mp3',

--- a/game/update.js
+++ b/game/update.js
@@ -1,6 +1,6 @@
 window.noname_update = {
-	version: "1.2.1",
-	update: "1.2.1",
+	version: "1.2.2",
+	update: "1.2.2",
 	changeLog: [
 		"增加bp可选角色数",
 		"增加自选士气最大值、战绩最大值、星杯最大值设置",

--- a/mode/xingBei.js
+++ b/mode/xingBei.js
@@ -149,8 +149,12 @@ export default () => {
 				}
 			},
 
-			checkOnlineResult:function(player){
-				return game.players[0].side==player.side;
+			checkOnlineResult:function(player,bool){
+				if(bool===true){
+					return game.me.side==player.side;
+				}else if(bool===false){
+					return game.me.side!=player.side;
+				}else return undefined;
 			},
 			getRoomInfo:function(uiintro){
 				if(lib.configOL.versus_mode=='4v4'){

--- a/mode/xingBei.js
+++ b/mode/xingBei.js
@@ -2731,9 +2731,10 @@ export default () => {
 					},list,ref);
 
 					game.addGlobalSkill('autoswap');
-					var list=game.getActivePlayersBySide();
-					for(var player of list){
-						if(get.itemtype(player)=='player') game.onSwapControl(player);
+					for(var player of game.players){
+						if(player==game.me || player.isOnline2()){
+							game.onSwapControl(player);
+						}
 					}
 				});
 			},

--- a/noname/game/index.js
+++ b/noname/game/index.js
@@ -6073,7 +6073,7 @@ export class Game extends GameCompatible {
 		let clients = game.players.concat(game.dead);
 		for (let i = 0; i < clients.length; i++) {
 			if (clients[i].isOnline2()) {
-				clients[i].send(game.over, dialog.content.innerHTML, game.checkOnlineResult(clients[i]));
+				clients[i].send(game.over, dialog.content.innerHTML, game.checkOnlineResult(clients[i],resultbool));
 			}
 		}
 

--- a/noname/game/index.js
+++ b/noname/game/index.js
@@ -5833,21 +5833,38 @@ export class Game extends GameCompatible {
 			td = document.createElement("td");
 			td.innerHTML = "受伤";
 			tr.appendChild(td);
+			//td = document.createElement("td");
+			//td.innerHTML = "摸牌";
+			//tr.appendChild(td);
+			//td = document.createElement("td");
+			//td.innerHTML = "出牌";
+			//tr.appendChild(td);
 			td = document.createElement("td");
-			td.innerHTML = "摸牌";
-			tr.appendChild(td);
-			td = document.createElement("td");
-			td.innerHTML = "出牌";
+			td.innerHTML = "产石";
 			tr.appendChild(td);
 			//td = document.createElement("td");
 			//td.innerHTML = "杀敌";
 			//tr.appendChild(td);
+			td = document.createElement("td");
+			td.innerHTML = "士气输出";
+			tr.appendChild(td);
+			td = document.createElement("td");
+			td.innerHTML = "士气亏损";
+			tr.appendChild(td);
+
+			td = document.createElement("td");
+			td.innerHTML = "治疗给予";
+			tr.appendChild(td);
+
+
 			table.appendChild(tr);
 			for (i = 0; i < game.players.length; i++) {
 				tr = document.createElement("tr");
+
 				td = document.createElement("td");
 				td.innerHTML = get.translation(game.players[i]) + (game.players[i].ai.stratagem_camouflage ? "(被伪装)" : "");
 				tr.appendChild(td);
+				
 				td = document.createElement("td");
 				num = 0;
 				for (j = 0; j < game.players[i].stat.length; j++) {
@@ -5855,6 +5872,7 @@ export class Game extends GameCompatible {
 				}
 				td.innerHTML = num;
 				tr.appendChild(td);
+
 				td = document.createElement("td");
 				num = 0;
 				for (j = 0; j < game.players[i].stat.length; j++) {
@@ -5862,6 +5880,7 @@ export class Game extends GameCompatible {
 				}
 				td.innerHTML = num;
 				tr.appendChild(td);
+				/*
 				td = document.createElement("td");
 				num = 0;
 				for (j = 0; j < game.players[i].stat.length; j++) {
@@ -5869,6 +5888,8 @@ export class Game extends GameCompatible {
 				}
 				td.innerHTML = num;
 				tr.appendChild(td);
+				*/
+				/*
 				td = document.createElement("td");
 				num = 0;
 				for (j = 0; j < game.players[i].stat.length; j++) {
@@ -5878,6 +5899,15 @@ export class Game extends GameCompatible {
 				}
 				td.innerHTML = num;
 				tr.appendChild(td);
+				*/
+				td = document.createElement("td");
+				num = 0;
+				for (j = 0; j < game.players[i].stat.length; j++) {
+					if (game.players[i].stat[j].addZhanJi != undefined) num += game.players[i].stat[j].addZhanJi;
+				}
+				td.innerHTML = num;
+				tr.appendChild(td);
+				
 				/*
 				td = document.createElement("td");
 				num = 0;
@@ -5887,6 +5917,31 @@ export class Game extends GameCompatible {
 				td.innerHTML = num;
 				tr.appendChild(td);
 				*/
+				
+				td = document.createElement("td");
+				num = 0;
+				for (j = 0; j < game.players[i].stat.length; j++) {
+					if (game.players[i].stat[j].changeShiQi != undefined) num += game.players[i].stat[j].changeShiQi;
+				}
+				td.innerHTML = num;
+				tr.appendChild(td);
+				
+				td = document.createElement("td");
+				num = 0;
+				for (j = 0; j < game.players[i].stat.length; j++) {
+					if (game.players[i].stat[j].changeShiQied != undefined) num += game.players[i].stat[j].changeShiQied;
+				}
+				td.innerHTML = num;
+				tr.appendChild(td);
+				
+				td = document.createElement("td");
+				num = 0;
+				for (j = 0; j < game.players[i].stat.length; j++) {
+					if (game.players[i].stat[j].addZhiLiao != undefined) num += game.players[i].stat[j].addZhiLiao;
+				}
+				td.innerHTML = num;
+				tr.appendChild(td);
+
 				table.appendChild(tr);
 			}
 			dialog.add(ui.create.div(".placeholder"));

--- a/noname/get/index.js
+++ b/noname/get/index.js
@@ -5733,7 +5733,7 @@ export class Get extends GetCompatible {
 		if(target.hasSkillTag('noZhiLiao')) return 0;
 		if(target.getZhiLiaoLimit()-target.zhiLiao<=0){
 			if(target.hasSkillTag('zhiLiaoYiChu')) return 0.2;
-			return 0.1;
+			return 0;
 		}
 		if(!num){
 			num=1;

--- a/noname/library/element/content.js
+++ b/noname/library/element/content.js
@@ -11859,6 +11859,31 @@ export const Content = {
 			}
 			
 		}
+
+		if(player.side!=side){//造成士气变动与事件玩家阵营不符时，则事件玩家为来源
+			if(player.stat[player.stat.length-1].changeShiQi==undefined){
+				player.stat[player.stat.length-1].changeShiQi=-num;
+			}
+			else{
+				player.stat[player.stat.length-1].changeShiQi+=-num;
+			}
+		}else{//自己变动了士气
+			if(player.stat[player.stat.length-1].changeShiQied==undefined){
+				player.stat[player.stat.length-1].changeShiQied=-num;
+			}
+			else{
+				player.stat[player.stat.length-1].changeShiQied+=-num;
+			}
+			if(source){
+				if(source.stat[source.stat.length-1].changeShiQi==undefined){
+					source.stat[source.stat.length-1].changeShiQi=-num;
+				}
+				else{
+					source.stat[source.stat.length-1].changeShiQi+=-num;
+				}
+			}
+		}
+		
 		var numx=num;
 		if(side==true){
 			game.hongShiQi+=num;
@@ -11901,6 +11926,13 @@ export const Content = {
 		var numx=num;
 		var name=get.translation(xingShi);
 		if(num>0){
+			if(player.stat[player.stat.length-1].addZhanJi==undefined){
+				player.stat[player.stat.length-1].addZhanJi=num;
+			}
+			else{
+				player.stat[player.stat.length-1].addZhanJi+=num;
+			}
+
 			if(side==true){
 				for(let i=0;i<num;i++){
 					game.hongZhanJi.push(xingShi);
@@ -11990,6 +12022,15 @@ export const Content = {
 		'step 0'
 		player.zhiLiao+=num;
 		if(num>=0){
+			var source=event.source;
+			if(!source) source=event.getParent().player;
+			if(source.stat[player.stat.length-1].addZhiLiao==undefined){
+				source.stat[player.stat.length-1].addZhiLiao=num;
+			}
+			else{
+				source.stat[player.stat.length-1].addZhiLiao+=num;
+			}
+
 			game.broadcastAll(function(){
 				game.playAudio("effect", "heal");
 			});

--- a/noname/library/element/player.js
+++ b/noname/library/element/player.js
@@ -2838,6 +2838,7 @@ export class Player extends HTMLDivElement {
 					}
 					str += "】";
 				}*/
+				str+='<br>';
 				if(config.characterPack.length>0){
 					str+='【';
 					for(var i=0;i<config.characterPack.length;i++){


### PR DESCRIPTION
更新素材版本
更新瘟疫法师瘟疫和战斗法师魔力增伤为新版faq，士气下降为直接伤害
优化吟游诗人禁忌诗篇代码
优化星坠女巫群星启示选择二选项ai，最低卢恩数改为5
优化血色剑灵赤色一闪ai
优化蝶舞者朝圣ai,爆士气情况下会使用茧
修复将刃放到王权宝珠上无法传递王权宝珠
优化贤者魔道法典ai
优化治疗收益计算
完善对局结束后统计信息
优化联机房间显示，将角色包换行显示
优化联机多选一对局起始多控显示
优化联机对局结束判断
